### PR TITLE
fix: change log function to work with set -euo pipefail

### DIFF
--- a/connector-restart
+++ b/connector-restart
@@ -48,8 +48,13 @@ log() {
     "${lvl^^}" "$(date-fmt)" "$msg"
 
   # Exiting the script when an error or success message appears
-  [ "${lvl,,}" == error ] && exit 1
-  [ "${lvl,,}" == success ] && exit 0
+  if [ "${lvl,,}" == error ]; then
+    exit 1
+  fi
+  
+  if [ "${lvl,,}" == success ]; then
+    exit 0
+  fi
 }
 
 get_connectors() {


### PR DESCRIPTION
When set -euo pipefail is used in a script, the script exits when there is a failure. There are side effects that one needs to be aware of like mentioned here https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425?permalink_comment_id=4326440#gistcomment-4326440. The log function in the script checks for "[ "${lvl,,}" == error ]" and uses && operator to exit. However when the condition check does not succeed, this gets treated as error and the script exits. The fix is to use if check here which does not cause set -e to trigger exit.